### PR TITLE
Switched to using default_branch name in place of master_branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Enforce Commit Style
 on: [push]
 
 jobs:
-  style_job:
+  style_job_local:
     runs-on: ubuntu-latest
     name: Enforce Commit Style
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const github = require('@actions/github');
 const { exec } = require('child_process');
 
 const MAX_SUBJECT_LENGTH = core.getInput('subject-length');
-const DEFAULT_BRANCH = github.context.payload.repository.master_branch;
+const DEFAULT_BRANCH = github.context.payload.repository.default_branch;
 const GET_SUBJECTS_COMMAND = 
  `git log --no-merges --no-abbrev --format=%s origin/${DEFAULT_BRANCH}..HEAD`;
 


### PR DESCRIPTION
The master_branch attribute is not present on repositories where the default branch isn't master.