### PR TITLE
Enforce no period at the end of the subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This action enforces some basic guidelines on commit subject messages.
 It will fail if:
 * The commit subject is longer than the `subject-length` variable (default: 55)
 * The commit subject does not begin with a capital letter
+* The commit subject ends with a period
+
+Some of the guidelines above are based on this [blog post](https://chris.beams.io/posts/git-commit/).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ const Subject = function(subject){
       core.setFailed(`Commit subject "${subject}" must begin with a capital`);
   }
 
+  function verifyNoPeriod(){
+    if (subject.substr(subject.length - 1) === '.')
+      core.setFailed(`Commit subject "${subject}" must not end with a period`);
+  }
+
   return {
     subject: subject,
     verify: function() {
@@ -38,6 +43,7 @@ const Subject = function(subject){
         return;
       verifyLength();
       verifyCapital();
+      verifyNoPeriod();
     }
   }
 }


### PR DESCRIPTION
Resolves #9 

According to [this blog post](https://chris.beams.io/posts/git-commit/),
one of the golden rules for good commit messages is to not have a period
at the end of the subject. We should enforce this as part of this GH action.

## Testing
- [x] Verified this check fails on a commit with a period
