### PR TITLE
Enforce no merge commits are in the branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,12 @@ const Subject = function(subject){
       core.setFailed(`Commit subject "${subject}" must begin with a capital`);
   }
 
+  function verifyNoMerge(){
+    if (subject.startsWith(`Merge branch '${DEFAULT_BRANCH}' into`))
+      core.setFailed(`Commits must not be merged from '${DEFAULT_BRANCH}'. ` +
+          `Use 'git fetch && git rebase origin/${DEFAULT_BRANCH}' instead`);
+  }
+
   return {
     subject: subject,
     verify: function() {
@@ -38,6 +44,7 @@ const Subject = function(subject){
         return;
       verifyLength();
       verifyCapital();
+      verifyNoMerge();
     }
   }
 }


### PR DESCRIPTION
Resolves #13 

We do not want developers to update their branch by merging master/main
 into their branch but to run `git fetch & git rebase` instead

